### PR TITLE
Ensure dist/ directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ $(TARGET_PACKAGE): $(TARGET_LOADABLE) $(TARGET_LOADABLE_NOFS) $(TARGET_OBJ) sqli
 	zip --junk-paths $@ $(TARGET_LOADABLE) $(TARGET_LOADABLE_NOFS) $(TARGET_OBJ) sqlite-lines.h sqlite-lines.c $(TARGET_SQLITE3) $(TARGET_CLI)
 
 $(TARGET_LOADABLE): sqlite-lines.c
+	mkdir -p dist
 	gcc -Isqlite \
 	$(LOADABLE_CFLAGS) \
 	$(DEFINE_SQLITE_LINES) \


### PR DESCRIPTION
Without this fix I got this error:

```
sqlite-lines % make loadable
gcc -Isqlite \
	-fPIC -shared \
	-DSQLITE_LINES_DATE="\"2022-08-03T18:05:03Z-0700\"" -DSQLITE_LINES_VERSION="\"v0.1.1\"" -DSQLITE_LINES_SOURCE="\"cfd99ea3b3fa21471f34d9571049ef0b5c0b61d2\"" \
	sqlite-lines.c -o dist/lines0.dylib
ld: can't open output file for writing: dist/lines0.dylib, errno=2 for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [dist/lines0.dylib] Error 1
```
With this fix that error no longer occurred and the `make loadable` command succeeded.